### PR TITLE
Add .env support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec
 
 gem 'formatador', github: 'geemus/formatador'
 gem 'unicode'
+gem 'dotenv'

--- a/README.md
+++ b/README.md
@@ -44,12 +44,17 @@ Commands:
 
 ## Setup
 
-APIKEY is read from environment variable.
+Usage of the `mandrilltemplate` command requires a Mandrill API key. You can set it in a `.env` file:
+
+```
+MANDRILL_APIKEY='your api key'
+```
+
+or set it as an environment variable:
 
 ```
 export MANDRILL_APIKEY='your api key'
 ```
-
 
 ## List templates
 

--- a/bin/mandrilltemplate
+++ b/bin/mandrilltemplate
@@ -2,6 +2,7 @@
 
 $LOAD_PATH.unshift File.join(File.dirname(__FILE__), %w[.. lib])
 
+require 'dotenv/load'
 require "thor"
 require "mandrill_template/cli"
 require "mandrill_template/monkey_create_file"

--- a/mandrill-template-manager.gemspec
+++ b/mandrill-template-manager.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "mandrill-api"
   spec.add_dependency "formatador"
   spec.add_dependency "unicode"
+  spec.add_dependency "dotenv"
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
Hey there -- I added support for setting the Mandrill API key via `.env` file. Feel free to merge in or ignore, just letting you know.